### PR TITLE
Configure all SendEvent results

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,19 @@ $mailer->registerPlugin($mailer_logger);
 The default log levels are:
 
 ```php
-    'sendPerformed.SUCCESS'     => LogLevel::INFO,
+    'sendPerformed.SUCCESS' => LogLevel::INFO,
+    'sendPerformed.TENTATIVE' => LogLevel::WARNING,
     'sendPerformed.NOT_SUCCESS' => LogLevel::ERROR,
-    'exceptionThrown'           => LogLevel::ERROR,
-    'beforeSendPerformed'       => LogLevel::DEBUG,
-    'commandSent'               => LogLevel::DEBUG,
-    'responseReceived'          => LogLevel::DEBUG,
-    'beforeTransportStarted'    => LogLevel::DEBUG,
-    'transportStarted'          => LogLevel::DEBUG,
-    'beforeTransportStopped'    => LogLevel::DEBUG,
-    'transportStopped'          => LogLevel::DEBUG,
+    'sendPerformed.PENDING' => LogLevel::DEBUG,
+    'sendPerformed.SPOOLED' => LogLevel::DEBUG,
+    'exceptionThrown' => LogLevel::ERROR,
+    'beforeSendPerformed' => LogLevel::DEBUG,
+    'commandSent' => LogLevel::DEBUG,
+    'responseReceived' => LogLevel::DEBUG,
+    'beforeTransportStarted' => LogLevel::DEBUG,
+    'transportStarted' => LogLevel::DEBUG,
+    'beforeTransportStopped' => LogLevel::DEBUG,
+    'transportStopped' => LogLevel::DEBUG,
 ```
 
 You can change the default log levels:

--- a/README.md
+++ b/README.md
@@ -33,19 +33,19 @@ $mailer->registerPlugin($mailer_logger);
 The default log levels are:
 
 ```php
-    'sendPerformed.SUCCESS' => LogLevel::INFO,
-    'sendPerformed.TENTATIVE' => LogLevel::WARNING,
+    'sendPerformed.SUCCESS'     => LogLevel::INFO,
+    'sendPerformed.TENTATIVE'   => LogLevel::WARNING,
     'sendPerformed.NOT_SUCCESS' => LogLevel::ERROR,
-    'sendPerformed.PENDING' => LogLevel::DEBUG,
-    'sendPerformed.SPOOLED' => LogLevel::DEBUG,
-    'exceptionThrown' => LogLevel::ERROR,
-    'beforeSendPerformed' => LogLevel::DEBUG,
-    'commandSent' => LogLevel::DEBUG,
-    'responseReceived' => LogLevel::DEBUG,
-    'beforeTransportStarted' => LogLevel::DEBUG,
-    'transportStarted' => LogLevel::DEBUG,
-    'beforeTransportStopped' => LogLevel::DEBUG,
-    'transportStopped' => LogLevel::DEBUG,
+    'sendPerformed.PENDING'     => LogLevel::DEBUG,
+    'sendPerformed.SPOOLED'     => LogLevel::DEBUG,
+    'exceptionThrown'           => LogLevel::ERROR,
+    'beforeSendPerformed'       => LogLevel::DEBUG,
+    'commandSent'               => LogLevel::DEBUG,
+    'responseReceived'          => LogLevel::DEBUG,
+    'beforeTransportStarted'    => LogLevel::DEBUG,
+    'transportStarted'          => LogLevel::DEBUG,
+    'beforeTransportStopped'    => LogLevel::DEBUG,
+    'transportStopped'          => LogLevel::DEBUG,
 ```
 
 You can change the default log levels:


### PR DESCRIPTION
I added config options for all of the statuses of the Swift_Events_SendEvent (including spooled https://github.com/swiftmailer/swiftmailer/pull/556)

This fixes an issue, where all result codes that are not SUCCESS are logged with the NON_SUCCESS level (assumed NON_SUCCESS).
Else log fills up with ERRORs for every message that is spooled (before real sending). If we lower the level then we can not distinguish the real errors.

In addition TENTATIVE status does not always mean that the sending failed. So log level for it should be configurable as well. Currently it will also be logged the same as failed (ERROR).

Also increased the visibility of private properties and log method so it is easier to extend (or decorate) the class